### PR TITLE
Update

### DIFF
--- a/CreateSQLProcedures.sql
+++ b/CreateSQLProcedures.sql
@@ -113,7 +113,7 @@ AS
 		[suspended],
 		[deleted],
 		[rebootRequired],
-		DATEADD(s, CAST(ROUND([warrantyDateEpoch] / 1000,0) AS INT), '1970-01-01') AS [warrantyDate],
+		[warrantyDate],
 		DATEADD(s, CAST(ROUND([lastAuditEpoch] / 1000,0) AS INT), '1970-01-01') AS [lastAudit],
 		DATEADD(s, CAST(ROUND([lastRebootEpoch] / 1000,0) AS INT), '1970-01-01') AS [lastReboot],
 		DATEADD(s, CAST(ROUND([lastSeenEpoch] / 1000,0) AS INT), '1970-01-01') AS [lastSeen],
@@ -143,7 +143,7 @@ AS
 		[suspended] BIT					'$.suspended',
 		[deleted] BIT					'$.deleted',
 		[rebootRequired] BIT			'$.rebootRequired',
-		[warrantyDateEpoch] BIGINT		'$.warrantyDate',
+		[warrantyDate] VARCHAR(MAX)		'$.warrantyDate',
 		[lastAuditEpoch] BIGINT			'$.lastAuditDate',
 		[lastRebootEpoch] BIGINT		'$.lastReboot',
 		[lastSeenEpoch] BIGINT			'$.lastSeen'

--- a/CreateSQLTables.sql
+++ b/CreateSQLTables.sql
@@ -13,7 +13,7 @@ CREATE TABLE [drmm].[sites](
 	[ondemand] BIT,
 	[deleted] BIT,
 	[autotaskName] VARCHAR(MAX),
-	[autotaskId] INT,
+	[autotaskId] VARCHAR(MAX),
 	[portalUrl] VARCHAR(MAX),
 	[lastUpdate] DATETIME
 )


### PR DESCRIPTION
Have found 2 small issues, and have updated them

In the CreateSQLTables.sql - The autotaskID can return "donotsync" if using DRM Mwith Autotask PSA and have set a site to not sync from DRMM to PSA. Update the Column type to VARCHAR(MAX) 

In CreateSQLProcedures.sql - The WarrantyDate is trying to be converted like the LastAudit/LastReboot time stamp, but the API returns the warranty date in yyyy-mm-dd format. have removed the conversion 

