### PR TITLE
Initial-Rollout-Fixes

### DIFF
--- a/CreateSQLProcedures.ps1
+++ b/CreateSQLProcedures.ps1
@@ -6,7 +6,7 @@ if (!$Config) {
 }
 
 # Import Module
-Remove-Module SQLPS
+Remove-Module SQLPS -ErrorAction SilentlyContinue
 Import-Module SQLServer -Force
 
 # Create SQL Connection Parameters

--- a/CreateSQLProcedures.ps1
+++ b/CreateSQLProcedures.ps1
@@ -6,6 +6,7 @@ if (!$Config) {
 }
 
 # Import Module
+Remove-Module SQLPS
 Import-Module SQLServer -Force
 
 # Create SQL Connection Parameters

--- a/CreateSQLProcedures.ps1
+++ b/CreateSQLProcedures.ps1
@@ -20,4 +20,4 @@ $sqlParams = [ordered]@{
 $connString = 'Server={0};Database={1};User Id={2};Password={3};' -f [array]$sqlParams.Values
 
 # Run SQL query to Create SQL Procedures
-Invoke-Sqlcmd -ConnectionString $connString -InputFile 'CreateProcedures.sql'
+Invoke-Sqlcmd -ConnectionString $connString -InputFile 'CreateSQLProcedures.sql'

--- a/CreateSQLTables.ps1
+++ b/CreateSQLTables.ps1
@@ -6,7 +6,7 @@ if (!$Config) {
 }
 
 # Import Module
-Remove-Module SQLPS
+Remove-Module SQLPS -ErrorAction SilentlyContinue
 Import-Module SQLServer -Force
 
 # Create SQL Connection Parameters

--- a/CreateSQLTables.ps1
+++ b/CreateSQLTables.ps1
@@ -6,6 +6,7 @@ if (!$Config) {
 }
 
 # Import Module
+Remove-Module SQLPS
 Import-Module SQLServer -Force
 
 # Create SQL Connection Parameters

--- a/CreateSQLTables.ps1
+++ b/CreateSQLTables.ps1
@@ -20,4 +20,4 @@ $sqlParams = [ordered]@{
 $connString = 'Server={0};Database={1};User Id={2};Password={3};' -f [array]$sqlParams.Values
 
 # Run SQL query to Create SQL Tables
-Invoke-Sqlcmd -ConnectionString $connString -InputFile 'CreateTables.sql'
+Invoke-Sqlcmd -ConnectionString $connString -InputFile 'CreateSQLTables.sql'

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ This contribution is a cooperation between Datto and myself, we both agreed to m
 You'll need a Microsoft SQL Server to store the Datto RMM data.  You can download [Microsoft SQL Express](https://www.microsoft.com/en-gb/sql-server/sql-server-downloads) for testing.  Store the SQL credentials in the provide registry import file.
 ## API
 You'll need to create API keys to run the PowerShell scripts.  Find more information how to create API keys in the [Datto Online Help](https://help.aem.autotask.net/en/Content/2SETUP/APIv2.htm).  Store the API keys in the provide registry file.
+## PowerShell
+You'll need to install the [SqlServer PowerShell Module](https://www.powershellgallery.com/packages/SqlServer) developed and maintained by Microsoft. You need to install it with the `AllowClobber` flag because of overlaps between SQLPS and SqlServer:
+```powershell
+Install-Module -Name SqlServer -AllowClobber
+```
 # Scripts
 ## Create SQL Tables
 You only need to run this [script](https://github.com/aaronengels/DrmmToPowerBI/blob/main/CreateSQLTables.ps1) once.  Alternatively run the [query](https://github.com/aaronengels/DrmmToPowerBI/blob/main/CreateSQLTables.sql) directly in SQL to create the tables in the database.  I decided to create a simple database [schema](https://github.com/aaronengels/DrmmToPowerBI/blob/main/SQLTables.jpg) that can be used easly to create dashboards and reports in Microsoft PowerBI.

--- a/UpdateSQLTables.ps1
+++ b/UpdateSQLTables.ps1
@@ -37,15 +37,15 @@
 		$connString = 'Server={0};Database={1};User Id={2};Password={3};' -f [array]$sqlParams.Values
 
 		# Truncate SQL temp tables
-		Invoke-Sqlcmd -ConnectionString $connString -Query "TRUNCATE TABLE temp.sites"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "TRUNCATE TABLE temp.devices"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "TRUNCATE TABLE temp.alerts"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "TRUNCATE TABLE temp.patchstatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "TRUNCATE TABLE temp.thirdpartystatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "TRUNCATE TABLE temp.avstatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "TRUNCATE TABLE temp.agentstatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "TRUNCATE TABLE temp.diskstatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "TRUNCATE TABLE temp.udfs"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "TRUNCATE TABLE temp.sites"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "TRUNCATE TABLE temp.devices"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "TRUNCATE TABLE temp.alerts"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "TRUNCATE TABLE temp.patchstatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "TRUNCATE TABLE temp.thirdpartystatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "TRUNCATE TABLE temp.avstatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "TRUNCATE TABLE temp.agentstatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "TRUNCATE TABLE temp.diskstatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "TRUNCATE TABLE temp.udfs"
 
 	}
 	catch {
@@ -66,7 +66,7 @@ PROCESS {
 			$json = $site | ConvertTo-Json
 		
 			# Insert site data into SQL temp table
-			Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.insertSite N'$json'"
+			Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.insertSite N'$json'"
 
 		}
 			
@@ -85,35 +85,35 @@ PROCESS {
 			$json = $device | ConvertTo-Json
 
 			# Insert device data into SQL temp table
-			Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.insertDevice N'$json'"
+			Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.insertDevice N'$json'"
 			
 			# Insert device Patch Status data into SQL temp table
-			Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.insertPatchStatus N'$json'"
+			Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.insertPatchStatus N'$json'"
 
 			# Insert device Third Party Status data into SQL temp table
-			Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.insertThirdPartyStatus N'$json'"
+			Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.insertThirdPartyStatus N'$json'"
 
 			# Insert device AV Status data into SQL temp table
-			Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.insertAVStatus N'$json'"
+			Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.insertAVStatus N'$json'"
 
 			# Insert device Agent Status data into SQL temp table
-			Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.insertAgentStatus N'$json'"
+			Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.insertAgentStatus N'$json'"
 
 			# Insert device UDF data into SQL temp table
-			Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.insertUDFs N'$json'"
+			Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.insertUDFs N'$json'"
 
 			# Insert device Disk Status data into SQL temp table
 			foreach ($disk in $device.logicalDisks) {
 				$disk | Add-Member -NotePropertyName deviceId -NotePropertyValue $device.id
 				$jsonDisk = $disk | ConvertTo-Json
-				Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.insertDiskStatus N'$jsonDisk'"
+				Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.insertDiskStatus N'$jsonDisk'"
 			}
 			
 			# Insert device alert data into SQL temp table
 			foreach($alert in Get-DrmmDeviceOpenAlerts $device.uid) {	
 				$alert | Add-Member -NotePropertyName deviceId -NotePropertyValue $device.id
 				$json = $alert | Add-DrmmAlertMessage | ConvertTo-Json
-				Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.insertAlert N'$json'"
+				Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.insertAlert N'$json'"
 			}
 		}	
 	}
@@ -129,15 +129,15 @@ END {
 	try {
 		
 		# Merge SQL temp tables 
-		Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.mergeSites"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.mergeDevices"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.mergeAlerts"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.mergePatchStatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.mergeThirdPartyStatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.mergeAvStatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.mergeAgentStatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.mergeDiskStatus"
-		Invoke-Sqlcmd -ConnectionString $connString -Query "EXEC drmm.mergeUDFs"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.mergeSites"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.mergeDevices"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.mergeAlerts"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.mergePatchStatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.mergeThirdPartyStatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.mergeAvStatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.mergeAgentStatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.mergeDiskStatus"
+		Invoke-Sqlcmd -ConnectionString $connString -QueryTimeout 0 -Query "EXEC drmm.mergeUDFs"
 	}
 	catch {
 

--- a/UpdateSQLTables.ps1
+++ b/UpdateSQLTables.ps1
@@ -10,7 +10,7 @@
 		}
 				
 		# Import Datto RMM Module
-		Remove-Module SQLPS
+		Remove-Module SQLPS -ErrorAction SilentlyContinue
 		Import-Module DattoRMM -Force
 		
 		# Set Datto RMM API Parameters
@@ -24,7 +24,6 @@
 		Set-DrmmApiParameters @apiParams -ErrorAction Stop
 
 		# Import SQL Server Module
-		Remove-Module PSSql
 		Import-Module SQLServer -Force
 
 		# Create SQL Connection Parameters

--- a/UpdateSQLTables.ps1
+++ b/UpdateSQLTables.ps1
@@ -10,6 +10,7 @@
 		}
 				
 		# Import Datto RMM Module
+		Remove-Module SQLPS
 		Import-Module DattoRMM -Force
 		
 		# Set Datto RMM API Parameters
@@ -23,6 +24,7 @@
 		Set-DrmmApiParameters @apiParams -ErrorAction Stop
 
 		# Import SQL Server Module
+		Remove-Module PSSql
 		Import-Module SQLServer -Force
 
 		# Create SQL Connection Parameters


### PR DESCRIPTION
This pull request contains five changes based on our experience getting it up and running for our use:

1. CreateSQLProcedures.ps1 now references Create**SQL**Procedures.sql
2. CreateSQLTables.ps1 now references Create**SQL**Tables.sql
3. I added `-QueryTimeout 0` to all instances of Invoke-SqlCmd. Although the Invoke-Sqlcmd documentation says that when this is not set, there is not limit, there is in fact a 30-second default timeout that will kick in with a large enough agent count. More details here: https://devblogs.microsoft.com/scripting/10-tips-for-the-sql-server-powershell-scripter/
4. I added code to explicitly remove the SQLPS module which is bundled with MSSQL. The prevents any confusion with cmdlets that are shared between SQLPS and SqlServer.
5. I updated the readme to include PowerShell requirements.